### PR TITLE
MP3Encoder 24-/32-Bit Encoding Fix for x64

### DIFF
--- a/Encoders/MP3Encoder.m
+++ b/Encoders/MP3Encoder.m
@@ -479,7 +479,7 @@ static int sLAMEBitrates [14] = { 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192
 	int				bufSize;
 	
 	int				result;
-	int32_t		    numWritten; // (see comment next to numWritten in encodeChunk:chunk:frameCount: for info about this type declaration)
+	int32_t		    numWritten; // (see comment next to numWritten in encodeChunk:frameCount: for info about this type declaration)
 	
 	@try {
 		buf = NULL;

--- a/Encoders/MP3Encoder.m
+++ b/Encoders/MP3Encoder.m
@@ -335,7 +335,8 @@ static int sLAMEBitrates [14] = { 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192
 	
 	void			**channelBuffers		= NULL;
 	short			**channelBuffers16		= NULL;
-	long			**channelBuffers32		= NULL;
+//	long			**channelBuffers32		= NULL; // when compiled for x64, long is, well, 64 bits! (not 32, as previously used here)
+    int             **channelBuffers32      = NULL; // int is still 32 bits in x64 (as you'd expect), so we'll use this instead of long
 	
 	int8_t			*buffer8				= NULL;
 	int16_t			*buffer16				= NULL;
@@ -407,10 +408,12 @@ static int sLAMEBitrates [14] = { 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192
 				break;
 				
 			case 24:
-				channelBuffers32 = (long **)channelBuffers;
+//				channelBuffers32 = (long **)channelBuffers;
+                channelBuffers32 = (int **)channelBuffers;
 				
 				for(channel = 0; channel < chunk->mBuffers[0].mNumberChannels; ++channel) {
-					channelBuffers32[channel] = calloc(frameCount, sizeof(long));
+//					channelBuffers32[channel] = calloc(frameCount, sizeof(long));
+                    channelBuffers32[channel] = calloc(frameCount, sizeof(int));
 					NSAssert(NULL != channelBuffers32[channel], NSLocalizedStringFromTable(@"Unable to allocate memory.", @"Exceptions", @""));
 				}
 				
@@ -424,30 +427,36 @@ static int sLAMEBitrates [14] = { 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192
 						constructedSample |= (uint8_t)*buffer8++;
 												
 						// Convert to 32-bit sample scaling
-						channelBuffers32[channel][wideSample] = (long)((constructedSample << 8) | (constructedSample & 0x000000ff));
+//						channelBuffers32[channel][wideSample] = (long)((constructedSample << 8) | (constructedSample & 0x000000ff));
+                        channelBuffers32[channel][wideSample] = (int)((constructedSample << 8) | (constructedSample & 0x000000ff));
 					}
 				}
 					
-				result = lame_encode_buffer_long2(_gfp, channelBuffers32[0], channelBuffers32[1], frameCount, buffer, bufferLen);
+//				result = lame_encode_buffer_long2(_gfp, channelBuffers32[0], channelBuffers32[1], frameCount, buffer, bufferLen);
+                result = lame_encode_buffer_int(_gfp, channelBuffers32[0], channelBuffers32[1], frameCount, buffer, bufferLen);
 				
 				break;
 				
 			case 32:
-				channelBuffers32 = (long **)channelBuffers;
+//				channelBuffers32 = (long **)channelBuffers;
+                channelBuffers32 = (int **)channelBuffers;
 				
 				for(channel = 0; channel < chunk->mBuffers[0].mNumberChannels; ++channel) {
-					channelBuffers32[channel] = calloc(frameCount, sizeof(long));
+//					channelBuffers32[channel] = calloc(frameCount, sizeof(long));
+                    channelBuffers32[channel] = calloc(frameCount, sizeof(int));
 					NSAssert(NULL != channelBuffers32[channel], NSLocalizedStringFromTable(@"Unable to allocate memory.", @"Exceptions", @""));
 				}
 					
 				buffer32 = chunk->mBuffers[0].mData;
 				for(wideSample = sample = 0; wideSample < frameCount; ++wideSample) {
 					for(channel = 0; channel < chunk->mBuffers[0].mNumberChannels; ++channel, ++sample) {
-						channelBuffers32[channel][wideSample] = (long)OSSwapBigToHostInt32(buffer32[sample]);
+//						channelBuffers32[channel][wideSample] = (long)OSSwapBigToHostInt32(buffer32[sample]);
+                        channelBuffers32[channel][wideSample] = (int)OSSwapBigToHostInt32(buffer32[sample]);
 					}
 				}
 					
-				result = lame_encode_buffer_long2(_gfp, channelBuffers32[0], channelBuffers32[1], frameCount, buffer, bufferLen);
+//				result = lame_encode_buffer_long2(_gfp, channelBuffers32[0], channelBuffers32[1], frameCount, buffer, bufferLen);
+                result = lame_encode_buffer_int(_gfp, channelBuffers32[0], channelBuffers32[1], frameCount, buffer, bufferLen);
 				
 				break;
 				


### PR DESCRIPTION
## Details

I was trying to convert one of my `wav` files to `mp3`, but resulting `mp3` was completely silent, despite having the correct duration. On closer inspection, I realized the `wav` was 32 bits per sample (@ 48 kHz), instead of the `wav` file I used in PR #1, which was 16 bits per sample (@ 44.1 kHz).

Checking the code in `Encoders/MP3Encoder.m` (specifically in the methods `encodeToFile:` and `encodeChunk:frameCount:`), when the bits per channel is 24 or 32, the channel buffers are initialized as `long`s, which is 64 bits on x64 (contradictory to the variable `channelBuffers32`).

As you could imagine, the fix was pretty straightforward: replace the `long` types with `int` to preserve the 32 bits. Additionally, since `lame_encode_buffer_long2` was being called in the 24 and 32 bit cases, it was replaced with `lame_encode_buffer_int` (also since the LAME framework was recompiled for x64).

Tried the conversion again and **it worked**! Hooray! Also tried it with a 24-bit `wav` file (@ 48 kHz) and converted to `mp3` just fine.

The other encoders *may* need some patching as well, but I'll take a look at them some other time.

## Changes

* Replaced `long` (64 bit) variable declarations with `int` (32 bit) in `Encoders/MP3Encoder.m`
* Changed `lame_encode_buffer_long2` method calls to `lame_encode_buffer_int`
* Fixed all warnings in `Encoders/MP3Encoder.m` (mostly implicit conversion warnings)
  - `ssize_t` and `size_t` (`typedef`s for `long` and `unsigned long`, respectively) were changed to `int32_t`
  - `fwrite` calls were casted to `int32_t` since it returns `size_t`